### PR TITLE
Update branchPropTest.R & getPopulationFit.R

### DIFF
--- a/R/branchPropTest.R
+++ b/R/branchPropTest.R
@@ -15,7 +15,7 @@ branchPropTest <- function(data, design, method = 't.test') {
   if (method == 't.test'){
     id1 = which(design[, 2] == 0)
     id2 = which(design[, 2] == 1)
-    res <- apply(data, 1, function(i)
+    res <- apply(data[,design[,1]], 1, function(i)
       t.test(i[id1], i[id2])$p.value)
     
   }

--- a/R/getPopulationFit.R
+++ b/R/getPopulationFit.R
@@ -17,7 +17,7 @@
 getPopulationFit <- function(testobj,
                              gene = NULL,
                              type = 'time',
-                             num.timepoint = 1e3){
+                             num.timepoint = max(testobj$pseudotime)){
   type <- toupper(type)
   if (!'testvar' %in% names(testobj)) {
     testvar <- testobj$testvar <- 2


### PR DESCRIPTION
It is important to arrange the samples in the branch cell proportions matrix such that they have the same order as the order of samples in the design data frame before running a t-test.  Fixes #23 

It is also important to set the default num.timepoint in the getPopulationFit() function to the maximum of the pseudotime vector, otherwise running plotGene() function downstream would result in subscript out of bounds error.