### PR TITLE
Fixing mc.cores > 1 error on Windows computers.

### DIFF
--- a/R/cluster_gene.R
+++ b/R/cluster_gene.R
@@ -44,7 +44,7 @@ cluster_gene <- function(testobj,
     set.seed(seed)
     # 
     if (k.auto){
-      clu <- mykmeans(mat.scale, maxclunum = 20)$cluster
+      clu <- mykmeans(mat.scale, maxclunum = 20, ncores = ncores)$cluster
     } else {
       clu <- kmeans(mat.scale, k, iter.max = 1000)$cluster
     }

--- a/R/evaluate_uncertainty.R
+++ b/R/evaluate_uncertainty.R
@@ -18,7 +18,8 @@ evaluate_uncertainty <-
            n.permute,
            subset.cell = NULL,
            design = NULL,
-           return.ctcomp = FALSE 
+           return.ctcomp = FALSE,
+           ncores = detectCores()
            # branchPropTest.method = 'ttest', ## this is a quick way to call the t-test in branchPropTest(); however, if want to use the multinom test, call branchPropTest() separately. 
            # branchPropTest.value.log = FALSE
   ) {
@@ -44,7 +45,7 @@ evaluate_uncertainty <-
       
       ## cluster cells
       invisible(capture.output(clu <-
-        mykmeans(pr.pm, number.cluster = max(inferobj$clusterid))$cluster))
+        mykmeans(pr.pm, number.cluster = max(inferobj$clusterid))$cluster), ncores = ncores)
       
       
       ## build pseudotime

--- a/R/infer_tree_structure.R
+++ b/R/infer_tree_structure.R
@@ -35,7 +35,8 @@ infer_tree_structure <-
            xlab = 'PC1',
            ylab = 'PC2',
            max.clunum = 50,
-           kmeans.seed = 12345) {
+           kmeans.seed = 12345,
+           ncores = detectCores()) {
     alls <- cellanno[, 2]
     names(alls) <- cellanno[, 1]
     ## set.seed(12345)
@@ -50,7 +51,7 @@ infer_tree_structure <-
     
     ## clustering
     clu <-
-      mykmeans(pr, maxclunum = 50, number.cluster = number.cluster, seed = kmeans.seed)$cluster
+      mykmeans(pr, maxclunum = 50, number.cluster = number.cluster, seed = kmeans.seed, ncores = ncores)$cluster
     table(clu)
     pd = data.frame(x = pr[, 1],
                     y = pr[, 2],

--- a/R/mykmeans.R
+++ b/R/mykmeans.R
@@ -16,14 +16,15 @@ mykmeans <-
   function(matrix,
            number.cluster = NA,
            maxclunum = 30,
-           seed = 12345) {
+           seed = 12345,
+           ncores = detectCores()) {
     library(parallel)
     if (is.na(number.cluster)) {
       rss <- mclapply(seq_len(maxclunum), function(clunum) {
         ## set.seed(seed)
         tmp <- kmeans(matrix, clunum, iter.max = 1000)
         tmp$betweenss / tmp$totss
-      }, mc.cores = 30)
+      }, mc.cores = ncores)
       rss <- unlist(rss)
       # number.cluster <- which(diff(rss) < 1e-2)[1]
       x <- 2:maxclunum


### PR DESCRIPTION
As per issue #29 the following pull request would fix the mc.cores > 1 error on Windows if users set ncores = 1 in `infer_tree_structure()`.